### PR TITLE
aタグの文字が長すぎる場合、改行されない問題

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,23 @@ module.exports = {
   content: ['./components/**/*.tsx', './pages/**/*.tsx'],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      typography: {
+        DEFAULT: {
+          css: {
+            a: {
+              wordBreak: 'break-all'
+            },
+            p: {
+              wordBreak: 'break-all'
+            },
+            li: {
+              wordBreak: 'break-all'
+            },
+          },
+        },
+      },
+    },
   },
   plugins: [require('@tailwindcss/typography')],
 }


### PR DESCRIPTION
問題
- aタグの英文字が長すぎる場合、親要素のwidthをはみ出していた。
- よく見たら、pタグ、liタグでも同様だった。

解決
- tailwind typographyを上書き

ハマったところ
- 何のタグにword-breakをつければいいかわからず
- tailwindの上書き方法　CSS-in-JS！
- tailwind自体の実装方法
 
参考文献
word-break - CSS: カスケーディングスタイルシート | MDN
https://developer.mozilla.org/ja/docs/Web/CSS/word-break 

@tailwindcss/typography - Tailwind CSS
https://tailwindcss.com/docs/typography-plugin#customizing-the-css

tailwindcss-typography/styles.js at master · tailwindlabs/tailwindcss-typography
https://github.com/tailwindlabs/tailwindcss-typography/blob/master/src/styles.js